### PR TITLE
URL Cleanup

### DIFF
--- a/common/common.xml
+++ b/common/common.xml
@@ -227,7 +227,7 @@
 			<javadoc.links sourcepath="@{input.dir}" destdir="@{output.dir}" classpathref="@{classpath.id}"
 					access="@{access}" excludepackagenames="@{exclude.package.names}" maxmemory="${javadoc.max.memory}"
 					stylesheetfile="${javadoc.stylesheet.file}" splitindex="true" useexternalfile="true">
-				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
+				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
 			</javadoc.links>
 			<copy toDir="@{output.dir}/resources">
 				<fileset dir="${javadoc.resources.dir}" erroronmissingdir="false"/>

--- a/multi-bundle/common.xml
+++ b/multi-bundle/common.xml
@@ -105,7 +105,7 @@
 			<javadoc.links sourcepath="@{input.dir}" destdir="@{output.dir}" classpathref="@{classpath.id}"
 					access="@{access}" excludepackagenames="@{exclude.package.names}" maxmemory="${javadoc.max.memory}"
 					stylesheetfile="${javadoc.stylesheet.file}" splitindex="true"  useexternalfile="true">
-				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
+				<header><![CDATA[<!-- Begin Google Analytics code --> <script type="text/javascript"> var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "https://www."); document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E")); </script> <script type="text/javascript"> var pageTracker = _gat._getTracker("UA-2728886-3"); pageTracker._setDomainName("none"); pageTracker._setAllowLinker(true); pageTracker._trackPageview(); </script> <!-- End Google Analytics code -->]]></header>
 			</javadoc.links>
 			<copy toDir="@{output.dir}/resources">
 				<fileset dir="${javadoc.resources.dir}" erroronmissingdir="false"/>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www (UnknownHostException) with 2 occurrences migrated to:  
  https://www ([https](https://www) result UnknownHostException).

# Ignored
These URLs were intentionally ignored.

* http://nwalsh.com/docbook/xsl/template/1.0 with 2 occurrences
* http://nwalsh.com/docbook/xsl/template/1.0/param with 2 occurrences
* http://www.w3.org/1999/XSL/Format with 1 occurrences
* http://www.w3.org/1999/XSL/Transform with 2 occurrences